### PR TITLE
fix(feature): stop re-navigation when launching intents after cold boot

### DIFF
--- a/app/src/main/kotlin/com/potatosheep/kite/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/potatosheep/kite/app/MainActivity.kt
@@ -110,7 +110,10 @@ class MainActivity : ComponentActivity() {
                     KiteApp(appState = appState)
                 }
 
-                intentResolver(appState.navController, intent)
+                if (uiState.isColdBoot) {
+                    intentResolver(appState.navController, intent)
+                    viewModel.isBooted()
+                }
 
                 // Allow intents to work when the app is running.
                 DisposableEffect(Unit) {

--- a/app/src/main/kotlin/com/potatosheep/kite/app/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/potatosheep/kite/app/MainActivityViewModel.kt
@@ -6,9 +6,10 @@ import com.potatosheep.kite.app.MainActivityUiState.Success
 import com.potatosheep.kite.app.MainActivityUiState.Loading
 import com.potatosheep.kite.core.data.repo.UserConfigRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
@@ -16,23 +17,35 @@ import javax.inject.Inject
 class MainActivityViewModel @Inject constructor(
     userConfigRepository: UserConfigRepository
 ) : ViewModel() {
+    private val _isColdBoot = MutableStateFlow(true)
+
     val uiState: StateFlow<MainActivityUiState> = userConfigRepository.userConfig
-        .map { Success(it.shouldHideOnboarding) }
+        .combine(_isColdBoot) { config, boot ->
+            Success(config.shouldHideOnboarding, boot)
+        }
         .stateIn(
             scope = viewModelScope,
             initialValue = Loading,
             started = SharingStarted.WhileSubscribed(5_000)
         )
+
+    fun isBooted() { _isColdBoot.value = false }
 }
 
 sealed interface MainActivityUiState {
     data object Loading : MainActivityUiState
 
-    data class Success(val shouldHideOnboarding: Boolean) : MainActivityUiState {
+    data class Success(
+        val shouldHideOnboarding: Boolean,
+        val isBooted: Boolean
+    ) : MainActivityUiState {
         override val shouldShowOnboarding: Boolean get() = !shouldHideOnboarding
+        override val isColdBoot: Boolean get() = isBooted
     }
 
     fun shouldKeepSplashScreen() = this is Loading
 
     val shouldShowOnboarding: Boolean get() = false
+
+    val isColdBoot: Boolean get() = true
 }


### PR DESCRIPTION
When app is launched via an intent, configuration changes cause the app to 're-navigate' to the intent's associated destination. This happens because the intent resolver is fired off every time a configuration change occurs.

Surround the intent resolver with an additional check to verify if the app has already resolved the intent to prevent this.