### PR TITLE
fix(core): stop always displaying followed feed when instance changes

### DIFF
--- a/core/data/src/main/kotlin/com/potatosheep/kite/core/data/repo/UserConfigRepository.kt
+++ b/core/data/src/main/kotlin/com/potatosheep/kite/core/data/repo/UserConfigRepository.kt
@@ -50,7 +50,8 @@ internal class DefaultUserConfigRepository @Inject constructor(
     ): List<Post> = networkDataSource.getPreferences(
         instanceUrl = instanceUrl,
         sort = sort,
-        subreddits = subreddits
+        subreddits = subreddits,
+        redirect = redirect
     ).map { it.toExternalModel() }
 
     override suspend fun setInstance(instanceUrl: String) {


### PR DESCRIPTION
App always displays the followed feed after an instance change, even if other feeds are selected. Use redirect parameter in getInstanceCookies to fix this.

Refs: 1be150f9